### PR TITLE
Update for cargo variable support

### DIFF
--- a/pkgs/build-support/rust/rust-utils.nix
+++ b/pkgs/build-support/rust/rust-utils.nix
@@ -160,12 +160,7 @@ let buildCrate = { crateName, crateVersion, crateAuthors,
       export CARGO_PKG_VERSION_MAJOR=${builtins.elemAt version 0}
       export CARGO_PKG_VERSION_MINOR=${builtins.elemAt version 1}
       export CARGO_PKG_VERSION_PATCH=${builtins.elemAt version 2}
-      if [ -n "${versionPre}" ]; then
-        export CARGO_PKG_VERSION_PRE="${versionPre}"
-      fi
-      if [ -n "$CARGO_PKG_VERSION_PRE" ]; then
-        unset CARGO_PKG_VERSION_PRE
-      fi
+      export CARGO_PKG_VERSION_PRE="${versionPre}"
 
 
       BUILD=""


### PR DESCRIPTION
Cargo defines a set of environment variables it [implicitly] guarentees will be available to a crate at build time by recommending the use of the `env!()` macro which interrupts the build if the env var is not defined.

1. Add CARGO_PKG_AUTHORS variable with a colon-delimited string of authors or, in the absence of an author list, an empty string.

2.  Always define CARGO_PKG_VERSION_PRE, even when no value exists.

See https://github.com/rust-lang/cargo/blob/master/src/doc/environment-variables.md#environment-variables-cargo-sets-for-crates
